### PR TITLE
feat: 부적절한 리뷰가 있을시, 신고 기능 추가

### DIFF
--- a/src/main/java/project/kiyobackend/report/application/ReportService.java
+++ b/src/main/java/project/kiyobackend/report/application/ReportService.java
@@ -1,0 +1,21 @@
+package project.kiyobackend.report.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.kiyobackend.report.domain.service.ReportDomainService;
+import project.kiyobackend.user.domain.User;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReportService {
+
+
+    private final ReportDomainService reportDomainService;
+
+    @Transactional
+    public Long saveReport(User currentUser, Long reviewId,String content) {
+        return reportDomainService.saveReport(currentUser,reviewId,content);
+    }
+}

--- a/src/main/java/project/kiyobackend/report/domain/domain/Report.java
+++ b/src/main/java/project/kiyobackend/report/domain/domain/Report.java
@@ -1,0 +1,41 @@
+package project.kiyobackend.report.domain.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.kiyobackend.common.util.jpa.JpaBaseEntity;
+import project.kiyobackend.review.domain.domain.Review;
+import project.kiyobackend.user.domain.User;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Report extends JpaBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    private String content;
+
+    @OneToOne
+    private User user;
+
+    @OneToOne
+    private Review review;
+
+    public static Report createReport(String content,User user, Review review)
+    {
+       return new Report(content,user,review);
+    }
+
+    private Report(String content,User user, Review review)
+    {
+        this.content = content;
+        this.user = user;
+        this.review = review;
+    }
+}

--- a/src/main/java/project/kiyobackend/report/domain/domain/ReportRepository.java
+++ b/src/main/java/project/kiyobackend/report/domain/domain/ReportRepository.java
@@ -1,0 +1,6 @@
+package project.kiyobackend.report.domain.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report,Long> {
+}

--- a/src/main/java/project/kiyobackend/report/domain/service/ReportDomainService.java
+++ b/src/main/java/project/kiyobackend/report/domain/service/ReportDomainService.java
@@ -1,0 +1,35 @@
+package project.kiyobackend.report.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.kiyobackend.exception.review.NotExistReviewException;
+import project.kiyobackend.exception.user.NotExistUserException;
+import project.kiyobackend.report.domain.domain.Report;
+import project.kiyobackend.report.domain.domain.ReportRepository;
+import project.kiyobackend.review.application.ReviewService;
+import project.kiyobackend.review.domain.domain.Review;
+import project.kiyobackend.review.domain.domain.ReviewRepository;
+import project.kiyobackend.user.application.UserService;
+import project.kiyobackend.user.domain.User;
+import project.kiyobackend.user.domain.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportDomainService {
+
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReportRepository reportRepository;
+
+    public Long saveReport(User currentUser, Long reviewId,String content) {
+
+        User findUser = userRepository.findByUserId(currentUser.getUserId()).orElseThrow(NotExistUserException::new);
+        Review findReview = reviewRepository.findById(reviewId).orElseThrow(NotExistReviewException::new);
+        Report report = Report.createReport(content, findUser, findReview);
+        Report saveReport = reportRepository.save(report);
+        return saveReport.getId();
+
+    }
+}

--- a/src/main/java/project/kiyobackend/report/presentation/ReportController.java
+++ b/src/main/java/project/kiyobackend/report/presentation/ReportController.java
@@ -1,0 +1,34 @@
+package project.kiyobackend.report.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import project.kiyobackend.auth.entity.CurrentUser;
+import project.kiyobackend.common.SuccessResponseDto;
+import project.kiyobackend.report.application.ReportService;
+import project.kiyobackend.report.presentation.dto.ReportRequestDto;
+import project.kiyobackend.review.application.ReviewService;
+import project.kiyobackend.user.domain.User;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "부적절한 리뷰에 대해서 신고하기")
+    @PostMapping("/review/{reviewId}")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<SuccessResponseDto> saveReport(@CurrentUser User currentUser, @PathVariable Long reviewId, @RequestBody ReportRequestDto reportRequestDto)
+    {
+        Long result = reportService.saveReport(currentUser, reviewId, reportRequestDto.getContent());
+        return ResponseEntity.ok(new SuccessResponseDto(true,result));
+
+    }
+
+
+
+}

--- a/src/main/java/project/kiyobackend/report/presentation/dto/ReportRequestDto.java
+++ b/src/main/java/project/kiyobackend/report/presentation/dto/ReportRequestDto.java
@@ -1,0 +1,13 @@
+package project.kiyobackend.report.presentation.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportRequestDto {
+    private String content;
+
+}


### PR DESCRIPTION
- 신고 기능은 로그인한 유저만 사용할 수 있도록 구현. 애초에 API 요청 시 USER 권한 없으면 Unauthorized 에러 발생
- 신고 자체를 엔티티로 분리해서 관리. 차후 신고 목록 관리할때 Report 엔티티만 조회한 후 신고한 유저와 신고 받은 유저 파악하기