### PR TITLE
feat: 공지사항 보여주는 기능 추가, 마이 페이지에 있어서 로그인 사용자가 조회 가능

### DIFF
--- a/src/main/java/project/kiyobackend/notice/application/NoticeService.java
+++ b/src/main/java/project/kiyobackend/notice/application/NoticeService.java
@@ -1,0 +1,23 @@
+package project.kiyobackend.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.kiyobackend.notice.domain.domain.Notice;
+import project.kiyobackend.notice.domain.domain.NoticeQueryRepository;
+import project.kiyobackend.notice.domain.domain.NoticeRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeService {
+
+    private final NoticeQueryRepository noticeQueryRepository;
+
+    public Slice<Notice> getNotice(Long lastStoreId, Pageable pageable) {
+
+       return noticeQueryRepository.getNotice(lastStoreId,pageable);
+    }
+}

--- a/src/main/java/project/kiyobackend/notice/domain/domain/Notice.java
+++ b/src/main/java/project/kiyobackend/notice/domain/domain/Notice.java
@@ -1,0 +1,40 @@
+package project.kiyobackend.notice.domain.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    private Long id;
+
+    @Column(name = "notice_title")
+    private String title;
+
+    @Column(name = "notice_content")
+    private String content;
+
+    public static Notice createNotice(String title,String content)
+    {
+        return new Notice(title,content);
+    }
+
+    private Notice(String title,String content)
+    {
+        this.title = title;
+        this.content = content;
+    }
+
+
+
+
+}

--- a/src/main/java/project/kiyobackend/notice/domain/domain/NoticeAssembler.java
+++ b/src/main/java/project/kiyobackend/notice/domain/domain/NoticeAssembler.java
@@ -1,0 +1,13 @@
+package project.kiyobackend.notice.domain.domain;
+
+import org.springframework.data.domain.Slice;
+import project.kiyobackend.notice.presentation.dto.NoticeResponse;
+
+public class NoticeAssembler {
+
+    public static Slice<NoticeResponse> NoticeResponse(Slice<Notice> notices)
+    {
+        return notices.map(n-> new NoticeResponse(n.getId(),n.getTitle(),n.getContent()));
+    }
+
+}

--- a/src/main/java/project/kiyobackend/notice/domain/domain/NoticeQueryRepository.java
+++ b/src/main/java/project/kiyobackend/notice/domain/domain/NoticeQueryRepository.java
@@ -1,0 +1,63 @@
+package project.kiyobackend.notice.domain.domain;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static project.kiyobackend.notice.domain.domain.QNotice.notice;
+import static project.kiyobackend.store.domain.domain.store.QStore.store;
+
+
+@Repository
+public class NoticeQueryRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+
+    public NoticeQueryRepository(EntityManager em)
+    {
+        this.em = em;
+        this.query = new JPAQueryFactory(em);
+    }
+
+
+    public Slice<Notice> getNotice(Long lastStoreId,Pageable pageable)
+    {
+        List<Notice> results = query.selectFrom(notice)
+                .where(ltNoticeId(lastStoreId))
+                .orderBy(notice.id.desc())
+                .limit(pageable.getPageSize()+1) // 나는 5개 요청해도 쿼리상 +시켜서 6개 들고 오게 함
+                .fetch();
+
+        return checkLastPage(pageable, results);
+    }
+
+    private BooleanExpression ltNoticeId(Long storeId) {
+        if (storeId == null) {
+            return null;
+        }
+
+        return store.id.lt(storeId);
+    }
+
+    private Slice<Notice> checkLastPage(Pageable pageable, List<Notice> results) {
+
+        boolean hasNext = false;
+
+        // 조회한 결과 개수가 요청한 페이지 사이즈보다 크면 뒤에 더 있음, next = true
+        if (results.size() > pageable.getPageSize()) {
+            hasNext = true;
+            results.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+}

--- a/src/main/java/project/kiyobackend/notice/domain/domain/NoticeRepository.java
+++ b/src/main/java/project/kiyobackend/notice/domain/domain/NoticeRepository.java
@@ -1,0 +1,6 @@
+package project.kiyobackend.notice.domain.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+}

--- a/src/main/java/project/kiyobackend/notice/presentation/NoticeController.java
+++ b/src/main/java/project/kiyobackend/notice/presentation/NoticeController.java
@@ -1,0 +1,33 @@
+package project.kiyobackend.notice.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.kiyobackend.notice.application.NoticeService;
+import project.kiyobackend.notice.domain.domain.Notice;
+import project.kiyobackend.notice.domain.domain.NoticeAssembler;
+import project.kiyobackend.notice.presentation.dto.NoticeResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Operation(summary = "전체 공지사항 조회")
+    @GetMapping
+    public ResponseEntity<Slice<NoticeResponse>> getNotice(@RequestParam(name = "lastStoreId", required = false)  Long lastStoreId, Pageable pageable)
+    {
+        Slice<Notice> results = noticeService.getNotice(lastStoreId, pageable);
+        return ResponseEntity.ok(NoticeAssembler.NoticeResponse(results));
+
+    }
+
+}

--- a/src/main/java/project/kiyobackend/notice/presentation/dto/NoticeResponse.java
+++ b/src/main/java/project/kiyobackend/notice/presentation/dto/NoticeResponse.java
@@ -1,0 +1,14 @@
+package project.kiyobackend.notice.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class NoticeResponse {
+
+    private Long noticeId;
+    private String title;
+    private String content;
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -297,3 +297,4 @@ values ( 1,20,1 ),
        (4,1,1);
 
 insert into qna (qna_id,content,user_id) values ( 1,'가게 승인이 좀 느린것 같아요!',1 );
+insert into notice (notice_id,notice_title,notice_content) values ( 1,'서비스 점검 시간 공지입니다.','9월 1일 20시부터 24시까지 시스템 점검에 들어가니 서비스 사용에 유의해주세요.' ),( 2,'이벤트 공지.','9월 2일부터 할인 이벤트 시작합니다!' );


### PR DESCRIPTION
- 공지사항은 마이페이지로 들어가야 하기 때문에 비로그인 사용자는 사용 불가
- 공지사항 등록/수정/삭제 기능은 차후 어드민 페이지 개발에서 적용할 예정